### PR TITLE
Change Netty version to 4.1.0.beta4-SNAPSHOT.

### DIFF
--- a/console/src/main/java/org/jboss/aerogear/webpush/Http2SettingsHandler.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/Http2SettingsHandler.java
@@ -38,7 +38,7 @@ public class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Setti
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, Http2Settings msg) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, Http2Settings msg) throws Exception {
         promise.setSuccess();
         // Only care about the first settings message
         ctx.pipeline().remove(this);

--- a/console/src/main/java/org/jboss/aerogear/webpush/HttpResponseHandler.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/HttpResponseHandler.java
@@ -57,31 +57,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-        /*
-        System.out.println("message received: " + msg);
-        Integer streamId = msg.headers().getInt(HttpUtil.ExtensionHeaderNames.STREAM_ID.text());
-        if (streamId == null) {
-            System.err.println("HttpResponseHandler unexpected message received: " + msg);
-            return;
-        }
-
-        ChannelPromise promise = streamidPromiseMap.get(streamId);
-        if (promise == null) {
-            System.err.println("Message received for unknown stream id " + streamId);
-        } else {
-            // Do stuff with the message (for now just print it)
-            ByteBuf content = msg.content();
-            if (content.isReadable()) {
-                int contentLength = content.readableBytes();
-                byte[] arr = new byte[contentLength];
-                content.readBytes(arr);
-                System.out.println(new String(arr, 0, contentLength, CharsetUtil.UTF_8));
-            }
-
-            promise.setSuccess();
-        }
-        */
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
     }
 
     @Override

--- a/console/src/main/java/org/jboss/aerogear/webpush/WebPushClient.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/WebPushClient.java
@@ -153,7 +153,7 @@ public class WebPushClient {
 
     private Http2Headers http2Headers(final HttpMethod method, final String url) {
         final URI hostUri = URI.create("https://" + host + ":" + port + "/" + url);
-        final Http2Headers headers = new DefaultHttp2Headers(false).method(method.name());
+        final Http2Headers headers = new DefaultHttp2Headers(false).method(AsciiString.of(method.name()));
         headers.path(asciiString(url));
         headers.authority(asciiString(hostUri.getAuthority()));
         headers.scheme(asciiString(hostUri.getScheme()));

--- a/console/src/main/java/org/jboss/aerogear/webpush/WebPushClientInitializer.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/WebPushClientInitializer.java
@@ -17,8 +17,8 @@
 package org.jboss.aerogear.webpush;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -127,12 +127,12 @@ public class WebPushClientInitializer extends ChannelInitializer<SocketChannel> 
     /**
      * A handler that triggers the cleartext upgrade to HTTP/2 by sending an initial HTTP request.
      */
-    private final class UpgradeRequestHandler extends ChannelHandlerAdapter {
+    private final class UpgradeRequestHandler extends ChannelInboundHandlerAdapter {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             DefaultFullHttpRequest upgradeRequest = new DefaultFullHttpRequest(HTTP_1_1, GET, "/");
             ctx.writeAndFlush(upgradeRequest);
-            super.channelActive(ctx);
+            ctx.fireChannelActive();
             ctx.pipeline().remove(this);
             WebPushClientInitializer.this.configureEndOfPipeline(ctx.pipeline());
         }
@@ -141,7 +141,7 @@ public class WebPushClientInitializer extends ChannelInitializer<SocketChannel> 
     /**
      * Class that logs any User Events triggered on this channel.
      */
-    private static class UserEventLogger extends ChannelHandlerAdapter {
+    private static class UserEventLogger extends ChannelInboundHandlerAdapter {
 
         private final EventHandler handler;
 
@@ -157,7 +157,7 @@ public class WebPushClientInitializer extends ChannelInitializer<SocketChannel> 
                     handler.message(sslEvent.cause().getMessage());
                 }
             }
-            super.userEventTriggered(ctx, evt);
+            ctx.fireUserEventTriggered(evt);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <aerogear.crypto.version>0.1.2</aerogear.crypto.version>
     <bouncycastle.version>140</bouncycastle.version>
     <version.exec-maven-plugin>1.2</version.exec-maven-plugin>
-    <netty.version>5.0.0.Alpha2-SNAPSHOT</netty.version>
+    <netty.version>4.1.0.Beta4-SNAPSHOT</netty.version>
     <jackson.version>2.3.0</jackson.version>
     <junit.version>4.11</junit.version>
     <easytesting.version>1.4</easytesting.version>

--- a/server-netty/src/main/java/org/jboss/aerogear/webpush/netty/WebPushHttp11Handler.java
+++ b/server-netty/src/main/java/org/jboss/aerogear/webpush/netty/WebPushHttp11Handler.java
@@ -46,7 +46,7 @@ public class WebPushHttp11Handler extends SimpleChannelInboundHandler<HttpReques
     }
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, HttpRequest req) throws Exception {
+    public void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws Exception {
         if (HttpHeaderUtil.is100ContinueExpected(req)) {
             ctx.write(new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.CONTINUE));
         }

--- a/server-netty/src/test/java/org/jboss/aerogear/webpush/netty/WebPushFrameListenerTest.java
+++ b/server-netty/src/test/java/org/jboss/aerogear/webpush/netty/WebPushFrameListenerTest.java
@@ -606,42 +606,42 @@ public class WebPushFrameListenerTest {
 
     private static Http2Headers registerHeaders() {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.POST.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.POST.name()));
         requestHeaders.path(asciiString("/webpush/" + Resource.REGISTER.resourceName()));
         return requestHeaders;
     }
 
     private static Http2Headers subHeaders(final AsciiString resourceUrl) {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.POST.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.POST.name()));
         requestHeaders.path(resourceUrl);
         return requestHeaders;
     }
 
     private static Http2Headers monitorHeaders(final AsciiString resourceUrl) {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.GET.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.GET.name()));
         requestHeaders.path(resourceUrl);
         return requestHeaders;
     }
 
     private static Http2Headers notifyHeaders(final AsciiString resourceUrl) {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.PUT.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.PUT.name()));
         requestHeaders.path(resourceUrl);
         return requestHeaders;
     }
 
     private static Http2Headers statusHeaders(final AsciiString resourceUrl) {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.GET.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.GET.name()));
         requestHeaders.path(resourceUrl);
         return requestHeaders;
     }
 
     private static Http2Headers subDeleteHeaders(final AsciiString resourceUrl) {
         final Http2Headers requestHeaders = new DefaultHttp2Headers(false);
-        requestHeaders.method(HttpMethod.DELETE.name());
+        requestHeaders.method(AsciiString.of(HttpMethod.DELETE.name()));
         requestHeaders.path(resourceUrl);
         return requestHeaders;
     }


### PR DESCRIPTION
Motivation:
We are currently using version 5.0.0.Alpha2-SNAPSHOT. But to release we
need a non-snapshot version. There will be a 4.1.0.beta4 release shortly
and we should update our code to make sure it work with that version.
This will make it easy for us to change to the non-snapshot version once
it is available.

Modifications:
Updated the version in the pom.xml and make modifications required for
the difference in Netty code base between 5.0.0 and 4.1.

Result:
Everything works as before and we'll be able to switch to 4.1.0.beta4
when it is available.

JIRA:
https://issues.jboss.org/browse/AGSYNC-46