### PR TITLE
Adding missing NPN distributions and adding docs

### DIFF
--- a/console/README.md
+++ b/console/README.md
@@ -14,6 +14,21 @@ extension Next Protocol Negotiation (NPN) and does currently not support Applica
 There is no NPN support for Java 1.8 so it is required that Java 1.7 be used to start the WebPush Console. This cannot
 be done as a choice at runtime as the jar files for either NPN or ALPN must be added to the Java boot classpath.
 
+For __Java 1.7__ the minor version is also important as different minor version of Java 1.7 require different
+[versions](http://www.eclipse.org/jetty/documentation/current/npn-chapter.html#npn-versions) of NPN.
+
+We provide different zip distributions for the various Java 1.7 and NPN version combinations:
+
+* 1.7.0_9 - 1.7.0_11      webpush-console-7_0_11.zip
+* 1.7.0_13                webpush-console-7_0_13.zip
+* 1.7.0_15 - 1.7.0_25     webpush-console-7_0_25.zip
+* 1.7.0_40 - 1.7.0_51     webpush-console-7_0_51.zip
+* 1.7.0_55 - 1.7.0_67     webpush-console-7_0_67.zip
+* 1.7.0_71 - 1.7.0_72     webpush-console-7_0_72.zip
+* 1.7.0_75 - 1.7.0_76     webpush-console-7_0_76.zip
+
+The above zip files can be found in the ```target``` directory after building.
+
 ### Start the AerogGear server
 __Java 1.8__ is required for the AeroGear WebPush Server.
 
@@ -34,6 +49,7 @@ The ```demo.key``` and ```selfsigned.crt``` can be found in [server-netty/src/ma
 ### Start the console
 __Java 1.8__ is required for the WebPush Console when connecting to the AeroGear WebPush Server, and __Java 1.7__ for
 the WebPush Console running against the node-webpush-server.
+
 
 Press ```tab``` to see the available commands and also to display the available options for specific commands.
 Most command also support a ```--help``` option to display information about options that the command accepts.

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -100,6 +100,21 @@
                                 <artifactId>npn-boot</artifactId>
                                 <version>1.1.9.v20141016</version>
                               </artifactItem>
+                              <artifactItem>
+                                <groupId>org.mortbay.jetty.npn</groupId>
+                                <artifactId>npn-boot</artifactId>
+                                <version>1.1.4.v20130313</version>
+                              </artifactItem>
+                              <artifactItem>
+                                <groupId>org.mortbay.jetty.npn</groupId>
+                                <artifactId>npn-boot</artifactId>
+                                <version>1.1.6.v20130911</version>
+                              </artifactItem>
+                              <artifactItem>
+                                <groupId>org.mortbay.jetty.npn</groupId>
+                                <artifactId>npn-boot</artifactId>
+                                <version>1.1.10.v20150130</version>
+                              </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -155,9 +170,12 @@
                     <descriptors>
                       <descriptor>src/assembly/jar.xml</descriptor>
                       <descriptor>src/assembly/zip-java-8.xml</descriptor>
-                      <descriptor>src/assembly/zip-java-7_0_25.xml</descriptor>
-                      <descriptor>src/assembly/zip-java-7_0_67.xml</descriptor>
+                      <descriptor>src/assembly/zip-java-7_0_76.xml</descriptor>
                       <descriptor>src/assembly/zip-java-7_0_72.xml</descriptor>
+                      <descriptor>src/assembly/zip-java-7_0_67.xml</descriptor>
+                      <descriptor>src/assembly/zip-java-7_0_51.xml</descriptor>
+                      <descriptor>src/assembly/zip-java-7_0_25.xml</descriptor>
+                      <descriptor>src/assembly/zip-java-7_0_13.xml</descriptor>
                     </descriptors>
                     <appendAssemblyId>true</appendAssemblyId>
                     <archive>
@@ -465,6 +483,34 @@
       </activation>
       <properties>
         <jetty.npn.version>1.1.9.v20141016</jetty.npn.version>
+        <jetty.alpn.version>7.1.2.v20141202</jetty.alpn.version>
+        <bootcp>${jetty.npn.path}</bootcp>
+      </properties>
+    </profile>
+    <profile>
+      <id>npn-alpn-7u75</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.7.0_75</value>
+        </property>
+      </activation>
+      <properties>
+        <jetty.npn.version>1.1.10.v20150130</jetty.npn.version>
+        <jetty.alpn.version>7.1.2.v20141202</jetty.alpn.version>
+        <bootcp>${jetty.npn.path}</bootcp>
+      </properties>
+    </profile>
+    <profile>
+      <id>npn-alpn-7u76</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.7.0_76</value>
+        </property>
+      </activation>
+      <properties>
+        <jetty.npn.version>1.1.10.v20150130</jetty.npn.version>
         <jetty.alpn.version>7.1.2.v20141202</jetty.alpn.version>
         <bootcp>${jetty.npn.path}</bootcp>
       </properties>

--- a/console/src/assembly/zip-java-7_0_13.xml
+++ b/console/src/assembly/zip-java-7_0_13.xml
@@ -1,0 +1,45 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>7_0_13</id>
+
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory/>
+      <includes>
+        <include>webpush-console-dist.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/libs</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>npn-boot-1.1.4.v20130313.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>console.sh</include>
+      </includes>
+      <fileMode>0744</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>README</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+
+</assembly>

--- a/console/src/assembly/zip-java-7_0_51.xml
+++ b/console/src/assembly/zip-java-7_0_51.xml
@@ -1,0 +1,45 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>7_0_51</id>
+
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory/>
+      <includes>
+        <include>webpush-console-dist.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/libs</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>npn-boot-1.1.6.v20130911.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>console.sh</include>
+      </includes>
+      <fileMode>0744</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>README</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+
+</assembly>

--- a/console/src/assembly/zip-java-7_0_76.xml
+++ b/console/src/assembly/zip-java-7_0_76.xml
@@ -1,0 +1,45 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>7_0_76</id>
+
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}</directory>
+      <outputDirectory/>
+      <includes>
+        <include>webpush-console-dist.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/libs</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>npn-boot-1.1.10.v20150130.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>console.sh</include>
+      </includes>
+      <fileMode>0744</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/src/main/resources</directory>
+      <outputDirectory/>
+      <includes>
+        <include>README</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+
+</assembly>


### PR DESCRIPTION
Motivation:
Currenlty not all Java 1.7 version and NPN combinations are available.
Also the documentation is not clear about this requirement which is has
become evident after pull request reviews.

Modifications:
Added the missing zip distributions and update console/readme with the
combinations spans and links to NPNs docs for further information.

Result:
Most Java 1.7 minor version are supported. There are a few older ones
that are not covered. But more importantly the lastest version are.