### PR TITLE
WIP: Updates for `draft-thomson-webpush-protocol-00`

### DIFF
--- a/console/src/main/java/org/jboss/aerogear/webpush/LinkHeaderDecoder.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/LinkHeaderDecoder.java
@@ -1,0 +1,104 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright Red Hat, Inc., and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.aerogear.webpush;
+
+import io.netty.handler.codec.AsciiString;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class LinkHeaderDecoder {
+    private static final Pattern CLEAN_HREF = Pattern.compile("^['\"\\s<]+|['\"\\s>]+$");
+    private static final Pattern CLEAN_PARAM = Pattern.compile("^['\"\\s]+|['\"\\s]+$");
+
+    private final AsciiString header;
+    private List<Map<String, String>> links;
+
+    public LinkHeaderDecoder(final AsciiString header) {
+        this.header = header;
+    }
+
+    private static String cleanURL(final AsciiString url) {
+        return CLEAN_HREF.matcher(url).replaceAll("");
+    }
+
+    private static String cleanParam(final AsciiString param) {
+        return CLEAN_PARAM.matcher(param).replaceAll("");
+    }
+
+    public List<Map<String, String>> getLinks() {
+        if (this.links != null) {
+            return this.links;
+        }
+        if (this.header == null || this.header.length() == 0) {
+            this.links = Collections.emptyList();
+            return this.links;
+        }
+        this.links = new ArrayList<Map<String, String>>();
+        final AsciiString[] headers = this.header.split(',');
+        for (AsciiString header : headers) {
+            final AsciiString[] params = header.split(';');
+            if (params.length < 1) {
+                continue;
+            }
+            final Map<String, String> link = new LinkedHashMap<String, String>();
+            link.put("href", cleanURL(params[0]));
+            for (int i = 1; i < params.length; i++) {
+                final AsciiString param = params[i];
+                final int valueIndex = param.indexOf(0x3d); // '='
+                String key, value;
+                if (valueIndex < 0 || valueIndex == param.length()) {
+                    key = value = cleanParam(param);
+                } else {
+                    key = cleanParam(param.subSequence(0, valueIndex));
+                    value = cleanParam(param.subSequence(valueIndex + 1));
+                }
+                link.put(key, value);
+            }
+            this.links.add(link);
+        }
+        return this.links;
+    }
+
+    public Map<String, String> getParamsByField(final String name, final String value) {
+        final List<Map<String, String>> links = this.getLinks();
+        for (Map<String, String> link : links) {
+            String param = link.get(name);
+            if (param != null && param.equals(value)) {
+                return link;
+            }
+        }
+        return null;
+    }
+
+    public String getURLByRel(final String rel) {
+        Map<String, String> params = this.getParamsByField("rel", rel);
+        if (params == null) {
+            return null;
+        }
+        return params.get("href");
+    }
+
+    public String toString() {
+      final List<Map<String, String>> links = this.getLinks();
+      return links.toString();
+    }
+}

--- a/console/src/main/java/org/jboss/aerogear/webpush/WebPushClient.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/WebPushClient.java
@@ -94,10 +94,6 @@ public class WebPushClient {
         }
     }
 
-    public void register(final String path) throws Exception {
-        writeRequest(POST, path, Unpooled.buffer());
-    }
-
     public void monitor(final String monitorUrl, final boolean now) throws Exception {
         final Http2Headers headers = http2Headers(GET, monitorUrl);
         if (now) {
@@ -110,10 +106,6 @@ public class WebPushClient {
         writeRequest(POST, subscribeUrl, Unpooled.buffer());
     }
 
-    public void status(final String endpointUrl) throws Exception {
-        writeRequest(GET, endpointUrl);
-    }
-
     public void deleteSubscription(final String endpointUrl) throws Exception {
         writeRequest(DELETE, endpointUrl);
     }
@@ -122,8 +114,28 @@ public class WebPushClient {
         writeJsonRequest(POST, aggregateUrl, copiedBuffer(json, UTF_8));
     }
 
-    public void notify(final String endpointUrl, final String payload) throws Exception {
-        writeRequest(PUT, endpointUrl, copiedBuffer(payload, UTF_8));
+    public void notify(final String endpointUrl, final String payload, final String receiptUrl) throws Exception {
+        final Http2Headers headers = http2Headers(POST, endpointUrl);
+        if (receiptUrl != null) {
+            headers.add(new AsciiString("push-receipt"), AsciiString.of(receiptUrl));
+        }
+        writeRequest(headers, copiedBuffer(payload, UTF_8));
+    }
+
+    public void updateNotification(final String messageUrl, final String payload) throws Exception {
+        writeRequest(PUT, messageUrl, copiedBuffer(payload, UTF_8));
+    }
+
+    public void ackNotification(final String messageUrl) throws Exception {
+        writeRequest(DELETE, messageUrl);
+    }
+
+    public void requestReceipts(final String receiptSubscribeUrl) throws Exception {
+        writeRequest(POST, receiptSubscribeUrl);
+    }
+
+    public void acks(final String receiptSubUrl) throws Exception {
+        writeRequest(GET, receiptSubUrl);
     }
 
     private void writeRequest(final HttpMethod method, final String url) throws Exception {
@@ -146,6 +158,10 @@ public class WebPushClient {
 
     private void writeJsonRequest(final HttpMethod method, final String url, final ByteBuf payload) throws Exception {
         final Http2Headers headers = http2Headers(method, url);
+        writeRequest(headers, payload);
+    }
+
+    private void writeRequest(final Http2Headers headers, final ByteBuf payload) throws Exception {
         handler.outbound(headers, payload);
         ChannelFuture requestFuture = channel.writeAndFlush(new WebPushMessage(headers, payload)).sync();
         requestFuture.sync();

--- a/console/src/main/java/org/jboss/aerogear/webpush/WebPushConsole.java
+++ b/console/src/main/java/org/jboss/aerogear/webpush/WebPushConsole.java
@@ -1,6 +1,7 @@
 package org.jboss.aerogear.webpush;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.CharsetUtil;
 import org.jboss.aesh.cl.CommandDefinition;
@@ -444,6 +445,16 @@ public class WebPushConsole {
 
         @Override
         public void inbound(Http2Headers headers, int streamId) {
+            AsciiString link = headers.getAndRemove(AsciiString.of("link"));
+            LinkHeaderDecoder decoder = new LinkHeaderDecoder(link);
+            String pushURL = decoder.getURLByRel("urn:ietf:params:push:message");
+            if (pushURL != null) {
+                printInbound("Push: " + pushURL, streamId);
+            }
+            String receiptSubURL = decoder.getURLByRel("urn:ietf:params:push:receipt:subscribe");
+            if (receiptSubURL != null) {
+                printInbound("Receipt Subscribe: " + receiptSubURL, streamId);
+            }
             printInbound(headers.toString(), streamId);
         }
 


### PR DESCRIPTION
Hi! Thanks so much for building and open-sourcing the console; I've been using it to test the Node server during development, and it's fantastic. :8ball: I made a few changes to support the [latest draft](https://github.com/unicorn-wg/webpush-protocol). In particular:

* Registration has been removed, in favor of having user agents create multiple subscriptions. The subscription response now includes `urn:ietf:params:push` and `urn:ietf:params:push:receipt` links. The app server uses `:push` to deliver messages, and `:push:receipt` to request an endpoint for delivery receipts. Each subscription also has a monitor URL included in the `Location` header.
* The notion of a subscription status (and fetching the last-delivered message) has been dropped, so I removed the `status` command.
* Added `ack`, `receipt`, and `acks` to support delivery receipts. The `receipt` command creates a subscription resource, returning the URL in the `Location` header. This can be passed to the `acks` command to listen for receipts, which are sent when a notification is acknowledged using the `ack` command.
* A new `update` command updates a pending notification, useful for collapsing messages. I don't think this is part of the draft yet, but there's some discussion at unicorn-wg/webpush-protocol#12 about this.

This PR won't really be useful until the AeroGear and Node servers support the latest draft...there's a development branch at kitcambridge/node-webpush-server#8, but it needs some attention.