### PR TITLE
remove alpn api, due to agent usage

### DIFF
--- a/console/pom.xml
+++ b/console/pom.xml
@@ -240,13 +240,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jetty.alpn</groupId>
-            <artifactId>alpn-api</artifactId>
-            <version>${alpn-api.version}</version>
-            <scope>provided</scope> <!-- Provided by alpn-boot -->
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.aesh</groupId>
             <artifactId>aesh</artifactId>
             <version>0.56</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
     <slf4j.version>1.7.5</slf4j.version>
     <additionalparam>-Xdoclint:none</additionalparam>
     <npn-api.version>1.1.1.v20141010</npn-api.version>
-    <alpn-api.version>1.1.2.v20150522</alpn-api.version>
 
     <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>

--- a/server-netty/pom.xml
+++ b/server-netty/pom.xml
@@ -60,13 +60,6 @@
         </dependency>
 
         <dependency>
-          <groupId>org.eclipse.jetty.alpn</groupId>
-          <artifactId>alpn-api</artifactId>
-          <version>${alpn-api.version}</version>
-          <scope>provided</scope> <!-- Provided by alpn-boot -->
-        </dependency>
-
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
             <version>1.1.30.Fork1</version>


### PR DESCRIPTION
@idelpivnitskiy @danbev looks like ALPN-API can be removed due to usage of the jetty-alpn-agent