### PR TITLE
Updating Netty version to 4.1.0.CR7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <aerogear.crypto.version>0.1.2</aerogear.crypto.version>
     <bouncycastle.version>140</bouncycastle.version>
     <version.exec-maven-plugin>1.2</version.exec-maven-plugin>
-    <netty.version>4.1.0.CR5</netty.version>
+    <netty.version>4.1.0.CR7</netty.version>
     <jackson.version>2.3.0</jackson.version>
     <junit.version>4.11</junit.version>
     <easytesting.version>1.4</easytesting.version>


### PR DESCRIPTION
Motivation:
Simply to keep up with the latest candidate release of Netty.

Modifications:
Updated the version of Netty to 4.1.0.CR7.

Result:
All test pass.